### PR TITLE
Float to string invariant culture

### DIFF
--- a/GCDConsoleLib/RasterOperators/Operators/LinearExtractor.cs
+++ b/GCDConsoleLib/RasterOperators/Operators/LinearExtractor.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using GCDConsoleLib.Utility;
+using System.Globalization;
 
 namespace GCDConsoleLib.Internal.Operators
 {
@@ -366,11 +367,11 @@ namespace GCDConsoleLib.Internal.Operators
             {
                 switch (item)
                 {
-                    case (ECols.FID): csvcols.Add(fid.ToString()); break;
-                    case (ECols.X): csvcols.Add((fractionalpt[0]).ToString()); break;
-                    case (ECols.Y): csvcols.Add((fractionalpt[1]).ToString()); break;
-                    case (ECols.DISTANCE): if (!String.IsNullOrEmpty(sFieldName)) csvcols.Add(feat.GetFieldAsDouble(sFieldName).ToString()); break;
-                    case (ECols.STATION): csvcols.Add((finalDist).ToString()); break;
+                    case (ECols.FID): csvcols.Add(fid.ToString(CultureInfo.InvariantCulture)); break;
+                    case (ECols.X): csvcols.Add((fractionalpt[0]).ToString(CultureInfo.InvariantCulture)); break;
+                    case (ECols.Y): csvcols.Add((fractionalpt[1]).ToString(CultureInfo.InvariantCulture)); break;
+                    case (ECols.DISTANCE): if (!String.IsNullOrEmpty(sFieldName)) csvcols.Add(feat.GetFieldAsDouble(sFieldName).ToString(CultureInfo.InvariantCulture)); break;
+                    case (ECols.STATION): csvcols.Add((finalDist).ToString(CultureInfo.InvariantCulture)); break;
                 }
             }
             for (int did = 0; did < _inputRasters.Count; did++)
@@ -383,7 +384,7 @@ namespace GCDConsoleLib.Internal.Operators
                     if (_buffer[0].Equals(inNodataVals[did]))
                         csvcols.Add("");
                     else
-                        csvcols.Add(_buffer[0].ToString());
+                        csvcols.Add(DynamicMath.invariantString(_buffer[0]));
 
                 }
                 else

--- a/GCDConsoleLib/Utility/DynamicMath.cs
+++ b/GCDConsoleLib/Utility/DynamicMath.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using UnitsNet;
 
 namespace GCDConsoleLib.Utility
@@ -13,6 +14,7 @@ namespace GCDConsoleLib.Utility
         public static dynamic Subtract(dynamic a, dynamic b) { return a - b; }
         public static dynamic Multiply(dynamic a, dynamic b) { return a * b; }
         public static dynamic Divide(dynamic a, dynamic b) { return a / b; }
+        public static String invariantString(dynamic a) { return a.ToString(CultureInfo.InvariantCulture); }
 
 
         /// <summary>

--- a/GCDCore/Project/DoDBase.cs
+++ b/GCDCore/Project/DoDBase.cs
@@ -215,18 +215,18 @@ namespace GCDCore.Project
         /// <remarks>This is used by budget segregations and so needs to be static and public</remarks>
         public static DoDStats DeserializeStatistics(XmlNode nodStatistics, UnitsNet.Area cellArea, UnitGroup units)
         {
-            UnitsNet.Area AreaErosion_Raw = UnitsNet.Area.From(double.Parse(nodStatistics.SelectSingleNode("Erosion/Raw/Area").InnerText), units.ArUnit);
-            UnitsNet.Area AreaDeposit_Raw = UnitsNet.Area.From(double.Parse(nodStatistics.SelectSingleNode("Deposition/Raw/Area").InnerText), units.ArUnit);
-            UnitsNet.Area AreaErosion_Thr = UnitsNet.Area.From(double.Parse(nodStatistics.SelectSingleNode("Erosion/Thresholded/Area").InnerText), units.ArUnit);
-            UnitsNet.Area AreaDeposit_Thr = UnitsNet.Area.From(double.Parse(nodStatistics.SelectSingleNode("Deposition/Thresholded/Area").InnerText), units.ArUnit);
+            UnitsNet.Area AreaErosion_Raw = UnitsNet.Area.From(double.Parse(nodStatistics.SelectSingleNode("Erosion/Raw/Area").InnerText, CultureInfo.InvariantCulture), units.ArUnit);
+            UnitsNet.Area AreaDeposit_Raw = UnitsNet.Area.From(double.Parse(nodStatistics.SelectSingleNode("Deposition/Raw/Area").InnerText, CultureInfo.InvariantCulture), units.ArUnit);
+            UnitsNet.Area AreaErosion_Thr = UnitsNet.Area.From(double.Parse(nodStatistics.SelectSingleNode("Erosion/Thresholded/Area").InnerText, CultureInfo.InvariantCulture), units.ArUnit);
+            UnitsNet.Area AreaDeposit_Thr = UnitsNet.Area.From(double.Parse(nodStatistics.SelectSingleNode("Deposition/Thresholded/Area").InnerText, CultureInfo.InvariantCulture), units.ArUnit);
 
-            UnitsNet.Volume VolErosion_Raw = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Erosion/Raw/Volume").InnerText), units.VolUnit);
-            UnitsNet.Volume VolDeposit_Raw = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Deposition/Raw/Volume").InnerText), units.VolUnit);
-            UnitsNet.Volume VolErosion_Thr = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Erosion/Thresholded/Volume").InnerText), units.VolUnit);
-            UnitsNet.Volume VolDeposit_Thr = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Deposition/Thresholded/Volume").InnerText), units.VolUnit);
+            UnitsNet.Volume VolErosion_Raw = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Erosion/Raw/Volume").InnerText, CultureInfo.InvariantCulture), units.VolUnit);
+            UnitsNet.Volume VolDeposit_Raw = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Deposition/Raw/Volume").InnerText, CultureInfo.InvariantCulture), units.VolUnit);
+            UnitsNet.Volume VolErosion_Thr = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Erosion/Thresholded/Volume").InnerText, CultureInfo.InvariantCulture), units.VolUnit);
+            UnitsNet.Volume VolDeposit_Thr = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Deposition/Thresholded/Volume").InnerText, CultureInfo.InvariantCulture), units.VolUnit);
 
-            UnitsNet.Volume VolErosion_Err = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Erosion/Error/Volume").InnerText), units.VolUnit);
-            UnitsNet.Volume VolDeposit_Err = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Deposition/Error/Volume").InnerText), units.VolUnit);
+            UnitsNet.Volume VolErosion_Err = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Erosion/Error/Volume").InnerText, CultureInfo.InvariantCulture), units.VolUnit);
+            UnitsNet.Volume VolDeposit_Err = UnitsNet.Volume.From(double.Parse(nodStatistics.SelectSingleNode("Deposition/Error/Volume").InnerText, CultureInfo.InvariantCulture), units.VolUnit);
 
             return new DoDStats(
                 AreaErosion_Raw, AreaDeposit_Raw, AreaErosion_Thr, AreaDeposit_Thr,
@@ -237,7 +237,7 @@ namespace GCDCore.Project
 
         private static UnitsNet.Area DeserializeArea(XmlNode nodParent, string nodName, UnitsNet.Units.AreaUnit unit)
         {
-            double value = double.Parse(nodParent.SelectSingleNode(nodName).InnerText);
+            double value = double.Parse(nodParent.SelectSingleNode(nodName).InnerText, CultureInfo.InvariantCulture);
             return UnitsNet.Area.From(value, unit);
         }
 

--- a/GCDCore/Project/DoDBase.cs
+++ b/GCDCore/Project/DoDBase.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using GCDConsoleLib;
 using GCDConsoleLib.GCD;
 using System.Xml;
+using System.Globalization;
 
 namespace GCDCore.Project
 {
@@ -164,19 +165,19 @@ namespace GCDCore.Project
             SerializeAreaVolume(xmlDoc, nodErosion.AppendChild(xmlDoc.CreateElement("Raw")), stats.ErosionRaw, stats.StatsUnits, stats.CellArea);
             SerializeAreaVolume(xmlDoc, nodErosion.AppendChild(xmlDoc.CreateElement("Thresholded")), stats.ErosionThr, stats.StatsUnits, stats.CellArea);
             nodErosion.AppendChild(xmlDoc.CreateElement("Error")).AppendChild(xmlDoc.CreateElement("Volume")).InnerText =
-                stats.ErosionErr.GetVolume(stats.CellArea, stats.StatsUnits).As(stats.StatsUnits.VolUnit).ToString("R");
+                stats.ErosionErr.GetVolume(stats.CellArea, stats.StatsUnits).As(stats.StatsUnits.VolUnit).ToString("R", CultureInfo.InvariantCulture);
 
             XmlNode nodDeposition = nodParent.AppendChild(xmlDoc.CreateElement("Deposition"));
             SerializeAreaVolume(xmlDoc, nodDeposition.AppendChild(xmlDoc.CreateElement("Raw")), stats.DepositionRaw, stats.StatsUnits, stats.CellArea);
             SerializeAreaVolume(xmlDoc, nodDeposition.AppendChild(xmlDoc.CreateElement("Thresholded")), stats.DepositionThr, stats.StatsUnits, stats.CellArea);
             nodDeposition.AppendChild(xmlDoc.CreateElement("Error")).AppendChild(xmlDoc.CreateElement("Volume")).InnerText =
-                stats.DepositionErr.GetVolume(stats.CellArea, stats.StatsUnits).As(stats.StatsUnits.VolUnit).ToString("R");
+                stats.DepositionErr.GetVolume(stats.CellArea, stats.StatsUnits).As(stats.StatsUnits.VolUnit).ToString("R", CultureInfo.InvariantCulture);
         }
 
         private static void SerializeAreaVolume(XmlDocument xmlDoc, XmlNode nodParent, GCDAreaVolume areaVol, UnitGroup units, UnitsNet.Area cellArea)
         {
-            nodParent.AppendChild(xmlDoc.CreateElement("Area")).InnerText = areaVol.GetArea(cellArea).As(units.ArUnit).ToString("R");
-            nodParent.AppendChild(xmlDoc.CreateElement("Volume")).InnerText = areaVol.GetVolume(cellArea, units).As(units.VolUnit).ToString("R");
+            nodParent.AppendChild(xmlDoc.CreateElement("Area")).InnerText = areaVol.GetArea(cellArea).As(units.ArUnit).ToString("R", CultureInfo.InvariantCulture);
+            nodParent.AppendChild(xmlDoc.CreateElement("Volume")).InnerText = areaVol.GetVolume(cellArea, units).As(units.VolUnit).ToString("R", CultureInfo.InvariantCulture);
         }
 
         private void SerializeSurface(XmlNode nodDoD, Surface surface, string nodName)

--- a/GCDCore/Project/DoDMinLoD.cs
+++ b/GCDCore/Project/DoDMinLoD.cs
@@ -4,6 +4,7 @@ using System.Xml;
 using System.Collections.Generic;
 using GCDConsoleLib;
 using GCDConsoleLib.GCD;
+using System.Globalization;
 
 namespace GCDCore.Project
 {
@@ -41,13 +42,13 @@ namespace GCDCore.Project
         public DoDMinLoD(XmlNode nodDoD)
             : base(nodDoD)
         {
-            Threshold = decimal.Parse(nodDoD.SelectSingleNode("Threshold").InnerText);
+            Threshold = decimal.Parse(nodDoD.SelectSingleNode("Threshold").InnerText, CultureInfo.InvariantCulture);
         }
 
         public override XmlNode Serialize(XmlNode nodParent)
         {
             XmlNode nodDoD = base.Serialize(nodParent);
-            nodDoD.InsertBefore(nodParent.OwnerDocument.CreateElement("Threshold"), nodDoD.SelectSingleNode("Statistics")).InnerText = Threshold.ToString();
+            nodDoD.InsertBefore(nodParent.OwnerDocument.CreateElement("Threshold"), nodDoD.SelectSingleNode("Statistics")).InnerText = Threshold.ToString(CultureInfo.InvariantCulture);
             return nodDoD;
         }
     }

--- a/GCDCore/Project/DoDProbabilistic.cs
+++ b/GCDCore/Project/DoDProbabilistic.cs
@@ -56,9 +56,9 @@ namespace GCDCore.Project
             XmlNode nodSpatCo = nodDoD.SelectSingleNode("SpatialCoherence");
             if (nodSpatCo != null)
             {
-                int windowSize = int.Parse(nodSpatCo.SelectSingleNode("WindowSize").InnerText);
-                int inflectinA = int.Parse(nodSpatCo.SelectSingleNode("InflectionA").InnerText);
-                int inflectinB = int.Parse(nodSpatCo.SelectSingleNode("InflectionB").InnerText);
+                int windowSize = int.Parse(nodSpatCo.SelectSingleNode("WindowSize").InnerText, CultureInfo.InvariantCulture);
+                int inflectinA = int.Parse(nodSpatCo.SelectSingleNode("InflectionA").InnerText, CultureInfo.InvariantCulture);
+                int inflectinB = int.Parse(nodSpatCo.SelectSingleNode("InflectionB").InnerText, CultureInfo.InvariantCulture);
                 SpatialCoherence = new CoherenceProperties(windowSize, inflectinA, inflectinB);
 
                 PosteriorProbability = DeserializeRaster(nodDoD, "PosteriorProbability");
@@ -92,9 +92,9 @@ namespace GCDCore.Project
             if (SpatialCoherence != null)
             {
                 XmlNode nodSpatCo = nodDod.AppendChild(nodParent.OwnerDocument.CreateElement("SpatialCoherence"));
-                nodSpatCo.AppendChild(nodParent.OwnerDocument.CreateElement("WindowSize")).InnerText = SpatialCoherence.BufferSize.ToString();
-                nodSpatCo.AppendChild(nodParent.OwnerDocument.CreateElement("InflectionA")).InnerText = SpatialCoherence.InflectionA.ToString();
-                nodSpatCo.AppendChild(nodParent.OwnerDocument.CreateElement("InflectionB")).InnerText = SpatialCoherence.InflectionB.ToString();
+                nodSpatCo.AppendChild(nodParent.OwnerDocument.CreateElement("WindowSize")).InnerText = SpatialCoherence.BufferSize.ToString(CultureInfo.InvariantCulture);
+                nodSpatCo.AppendChild(nodParent.OwnerDocument.CreateElement("InflectionA")).InnerText = SpatialCoherence.InflectionA.ToString(CultureInfo.InvariantCulture);
+                nodSpatCo.AppendChild(nodParent.OwnerDocument.CreateElement("InflectionB")).InnerText = SpatialCoherence.InflectionB.ToString(CultureInfo.InvariantCulture);
             }
 
             return nodDod;

--- a/GCDCore/Project/DoDProbabilistic.cs
+++ b/GCDCore/Project/DoDProbabilistic.cs
@@ -4,6 +4,7 @@ using System.Xml;
 using System.Collections.Generic;
 using GCDConsoleLib;
 using GCDConsoleLib.GCD;
+using System.Globalization;
 
 namespace GCDCore.Project
 {
@@ -49,7 +50,7 @@ namespace GCDCore.Project
         public DoDProbabilistic(XmlNode nodDoD)
             : base(nodDoD)
         {
-            ConfidenceLevel = decimal.Parse(nodDoD.SelectSingleNode("ConfidenceLevel").InnerText);
+            ConfidenceLevel = decimal.Parse(nodDoD.SelectSingleNode("ConfidenceLevel").InnerText, CultureInfo.InvariantCulture);
             PriorProbability = DeserializeRaster(nodDoD, "PriorProbability");
 
             XmlNode nodSpatCo = nodDoD.SelectSingleNode("SpatialCoherence");
@@ -70,7 +71,7 @@ namespace GCDCore.Project
         public override XmlNode Serialize(XmlNode nodParent)
         {
             XmlNode nodDod = base.Serialize(nodParent);
-            nodDod.InsertBefore(nodParent.OwnerDocument.CreateElement("ConfidenceLevel"), nodDod.SelectSingleNode("Statistics")).InnerText = ConfidenceLevel.ToString();
+            nodDod.InsertBefore(nodParent.OwnerDocument.CreateElement("ConfidenceLevel"), nodDod.SelectSingleNode("Statistics")).InnerText = ConfidenceLevel.ToString(CultureInfo.InvariantCulture);
 
             // Prior probability always exists, regardless of whether spatial coherence was used.
             nodDod.AppendChild(nodParent.OwnerDocument.CreateElement("PriorProbability")).InnerText = ProjectManager.Project.GetRelativePath(PriorProbability.GISFileInfo);

--- a/GCDCore/Project/ErrorSurfaceProperty.cs
+++ b/GCDCore/Project/ErrorSurfaceProperty.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Collections.Generic;
 using System.Xml;
 using System.Linq;
+using System.Globalization;
 
 namespace GCDCore.Project
 {
@@ -110,7 +111,7 @@ namespace GCDCore.Project
 
             if (nodUni is XmlNode)
             {
-                UniformValue = decimal.Parse(nodUni.InnerText);
+                UniformValue = decimal.Parse(nodUni.InnerText, CultureInfo.InvariantCulture);
             }
             else if (surf is DEMSurvey)
             {
@@ -135,7 +136,7 @@ namespace GCDCore.Project
             nodParent.AppendChild(nodParent.OwnerDocument.CreateElement("Name")).InnerText = Name;
 
             if (UniformValue.HasValue)
-                nodParent.AppendChild(nodParent.OwnerDocument.CreateElement("UniformValue")).InnerText = UniformValue.Value.ToString();
+                nodParent.AppendChild(nodParent.OwnerDocument.CreateElement("UniformValue")).InnerText = UniformValue.Value.ToString(CultureInfo.InvariantCulture);
 
             if (FISRuleFile is ErrorCalculation.FIS.FISLibraryItem)
                 nodParent.AppendChild(nodParent.OwnerDocument.CreateElement("FISRuleFile")).InnerText = ProjectManager.Project.GetRelativePath(FISRuleFile.FilePath);

--- a/GCDCore/Project/GCDProject.cs
+++ b/GCDCore/Project/GCDProject.cs
@@ -333,7 +333,7 @@ namespace GCDCore.Project
             UnitsNet.Area cellArea = UnitsNet.Area.From(0, area);
             XmlNode nodCellArea = nodProject.SelectSingleNode("CellArea");
             if (!string.IsNullOrEmpty(nodCellArea.InnerText))
-                cellArea = UnitsNet.Area.From(double.Parse(nodCellArea.InnerText), area);
+                cellArea = UnitsNet.Area.From(double.Parse(nodCellArea.InnerText, CultureInfo.InvariantCulture), area);
 
             ProjectManager.Project = new GCDProject(name, desc, projectFile, dtCreated, gcdv, cellArea, units);
 

--- a/GCDCore/Project/GCDProject.cs
+++ b/GCDCore/Project/GCDProject.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Collections.Generic;
 using System.Xml;
+using System.Globalization;
 
 namespace GCDCore.Project
 {
@@ -251,7 +252,7 @@ namespace GCDCore.Project
 
             XmlNode nodArea = nodProject.AppendChild(xmlDoc.CreateElement("CellArea"));
             if (CellArea.As(Units.ArUnit) > 0)
-                nodArea.InnerText = CellArea.As(Units.ArUnit).ToString("R");
+                nodArea.InnerText = CellArea.As(Units.ArUnit).ToString("R", CultureInfo.InvariantCulture);
 
             if (DEMSurveys.Count > 0)
             {

--- a/GCDCore/Project/LinearExtraction/LinearExtraction.cs
+++ b/GCDCore/Project/LinearExtraction/LinearExtraction.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using GCDCore.Project.ProfileRoutes;
 using GCDCore.Project;
+using System.Globalization;
 
 namespace GCDCore.Project.LinearExtraction
 {
@@ -35,14 +36,14 @@ namespace GCDCore.Project.LinearExtraction
         {
             ProfileRoute = ProjectManager.Project.ProfileRoutes.First(x => string.Compare(x.Name, nodItem.SelectSingleNode("ProfileRoute").InnerText, true) == 0);
             Database = ProjectManager.Project.GetAbsolutePath(nodItem.SelectSingleNode("Database").InnerText);
-            SampleDistance = decimal.Parse(nodItem.SelectSingleNode("SampleDistance").InnerText);
+            SampleDistance = decimal.Parse(nodItem.SelectSingleNode("SampleDistance").InnerText, CultureInfo.InvariantCulture);
         }
 
         public virtual XmlNode Serialize(XmlNode nodParent)
         {
             XmlNode nodLE = nodParent.AppendChild(nodParent.OwnerDocument.CreateElement("LinearExtraction"));
             nodLE.AppendChild(nodParent.OwnerDocument.CreateElement("Name")).InnerText = Name;
-            nodLE.AppendChild(nodParent.OwnerDocument.CreateElement("SampleDistance")).InnerText = SampleDistance.ToString();
+            nodLE.AppendChild(nodParent.OwnerDocument.CreateElement("SampleDistance")).InnerText = SampleDistance.ToString(CultureInfo.InvariantCulture);
             nodLE.AppendChild(nodParent.OwnerDocument.CreateElement("ProfileRoute")).InnerText = ProfileRoute.Name;
             nodLE.AppendChild(nodParent.OwnerDocument.CreateElement("Database")).InnerText = ProjectManager.Project.GetRelativePath(Database);
             return nodLE;

--- a/GCDCore/Project/Morphological/MorphologicalAnalysis.cs
+++ b/GCDCore/Project/Morphological/MorphologicalAnalysis.cs
@@ -68,9 +68,9 @@ namespace GCDCore.Project.Morphological
             _DisplayUnits_Mass = UnitsNet.Units.MassUnit.Kilogram;
 
             _duration = Duration.From(double.Parse(nodDuration.InnerText, CultureInfo.InvariantCulture), DisplayUnits_Duration);
-            _porosity = decimal.Parse(nodAnalysis.SelectSingleNode("Porosity").InnerText);
-            _density = decimal.Parse(nodAnalysis.SelectSingleNode("Density").InnerText);
-            _competency = decimal.Parse(nodAnalysis.SelectSingleNode("Competency").InnerText);
+            _porosity = decimal.Parse(nodAnalysis.SelectSingleNode("Porosity").InnerText, CultureInfo.InvariantCulture);
+            _density = decimal.Parse(nodAnalysis.SelectSingleNode("Density").InnerText, CultureInfo.InvariantCulture);
+            _competency = decimal.Parse(nodAnalysis.SelectSingleNode("Competency").InnerText, CultureInfo.InvariantCulture);
             //_DataVolumeUnits = ProjectManager.Project.Units.VolUnit;
 
             double minFluxValue = double.Parse(nodAnalysis.SelectSingleNode("MinimumFluxVolume").InnerText, CultureInfo.InvariantCulture);
@@ -366,9 +366,9 @@ namespace GCDCore.Project.Morphological
             XmlNode nodMA = nodParent.AppendChild(nodParent.OwnerDocument.CreateElement("MorphologicalAnalysis"));
             nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Name")).InnerText = Name;
             nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Folder")).InnerText = ProjectManager.Project.GetRelativePath(OutputFolder.FullName);
-            nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Porosity")).InnerText = Porosity.ToString();
-            nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Density")).InnerText = Density.ToString();
-            nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Competency")).InnerText = Competency.ToString();
+            nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Porosity")).InnerText = Porosity.ToString(CultureInfo.InvariantCulture);
+            nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Density")).InnerText = Density.ToString(CultureInfo.InvariantCulture);
+            nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Competency")).InnerText = Competency.ToString(CultureInfo.InvariantCulture);
             nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Spreadsheet")).InnerText = ProjectManager.Project.GetRelativePath(Spreadsheet);
 
             XmlNode nodDuration = nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Duration"));

--- a/GCDCore/Project/Morphological/MorphologicalAnalysis.cs
+++ b/GCDCore/Project/Morphological/MorphologicalAnalysis.cs
@@ -67,13 +67,13 @@ namespace GCDCore.Project.Morphological
             _DisplayUnits_Volume = ProjectManager.Project.Units.VolUnit;
             _DisplayUnits_Mass = UnitsNet.Units.MassUnit.Kilogram;
 
-            _duration = Duration.From(double.Parse(nodDuration.InnerText), DisplayUnits_Duration);
+            _duration = Duration.From(double.Parse(nodDuration.InnerText, CultureInfo.InvariantCulture), DisplayUnits_Duration);
             _porosity = decimal.Parse(nodAnalysis.SelectSingleNode("Porosity").InnerText);
             _density = decimal.Parse(nodAnalysis.SelectSingleNode("Density").InnerText);
             _competency = decimal.Parse(nodAnalysis.SelectSingleNode("Competency").InnerText);
             //_DataVolumeUnits = ProjectManager.Project.Units.VolUnit;
 
-            double minFluxValue = double.Parse(nodAnalysis.SelectSingleNode("MinimumFluxVolume").InnerText);
+            double minFluxValue = double.Parse(nodAnalysis.SelectSingleNode("MinimumFluxVolume").InnerText, CultureInfo.InvariantCulture);
             BoundaryFlux = Volume.From(minFluxValue, ProjectManager.Project.Units.VolUnit);
 
             Units = new BindingList<MorphologicalUnit>();

--- a/GCDCore/Project/Morphological/MorphologicalAnalysis.cs
+++ b/GCDCore/Project/Morphological/MorphologicalAnalysis.cs
@@ -6,6 +6,7 @@ using UnitsNet;
 using System.ComponentModel;
 using System.Xml;
 using GCDCore.Engines;
+using System.Globalization;
 
 namespace GCDCore.Project.Morphological
 {
@@ -371,7 +372,7 @@ namespace GCDCore.Project.Morphological
             nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Spreadsheet")).InnerText = ProjectManager.Project.GetRelativePath(Spreadsheet);
 
             XmlNode nodDuration = nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("Duration"));
-            nodDuration.InnerText = Duration.As(DisplayUnits_Duration).ToString("R");
+            nodDuration.InnerText = Duration.As(DisplayUnits_Duration).ToString("R", CultureInfo.InvariantCulture);
             nodDuration.Attributes.Append(nodParent.OwnerDocument.CreateAttribute("units")).InnerText = DisplayUnits_Duration.ToString();
 
             XmlNode nodMinFluxCell = nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("MinimumFluxUnit"));
@@ -379,7 +380,7 @@ namespace GCDCore.Project.Morphological
                 nodMinFluxCell.InnerText = BoundaryFluxUnit.Name;
 
             XmlNode nodMinFlux = nodMA.AppendChild(nodParent.OwnerDocument.CreateElement("MinimumFluxVolume"));
-            nodMinFlux.InnerText = BoundaryFlux.As(ProjectManager.Project.Units.VolUnit).ToString("R");
+            nodMinFlux.InnerText = BoundaryFlux.As(ProjectManager.Project.Units.VolUnit).ToString("R", CultureInfo.InvariantCulture);
         }
 
         public override void Delete()


### PR DESCRIPTION
Making the format of writing and reading floating points to the GCD project file invariant of the host computer's culture settings. i.e. avoiding commas as decimal character in floating point strings.